### PR TITLE
Renames major exports (breaking changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HIRO Graph Javascript Libraries
 
-These libraries are for interacting with the HIRO Graph API. For full details of the API see the [HIRO Graph Docs](https://docs.hiro.arago.co/hiro/5.4.2/developer/hiro-graph-api/).
+These libraries are for interacting with the HIRO Graph API. For full details of the API see the [HIRO Graph Docs](https://docs.hiro.arago.co/hiro/current/developer/hiro-graph-api/).
 
 ## Packages
 

--- a/packages/hiro-graph-client/README.md
+++ b/packages/hiro-graph-client/README.md
@@ -1,13 +1,39 @@
 # `hiro-graph-client`: HIRO Graph API Client Javascript Library
 
-This is an isomorphic HIRO Graph Client library which exports two named items, `Token` and `Connection`.
+This is an isomorphic HIRO Graph Client library which exports, by default a `Client` and a named export: `Token`.
+
+## Client
+
+This is a client which performs the API calls against the HIRO Graph API for you, mantaining a persistent connection to the server. It will work with WebSockets if possible, but falls back to HTTP if not. It requires a `Token` which will then be used for all requests. All Exposed API methods return `Promise`s.
+
+```
+import Client from "hiro-graph-client";
+
+const client = new Client({ 
+    endpoint: "http://localhost:8888", 
+    token: someTokenInstance 
+});
+```
+
+The second argument to Client can be a `Transport` if you have a custom one, or a set of options for the client. If websockets are available, i.e. most modern browsers and when in node.js, then the default transport is a pool of websockets. The pool only has one socket by default, as in the browser this is most likely what you want, however on the backend you may wish to up this to more than a single connection.
+
+```
+import Client from "hiro-graph-client";
+
+const client = new Client({
+        endpoint: "http://localhost:8888",
+        token: someTokenInstance
+    }, { 
+        poolSize: 10
+    });
+```
 
 ## Token
 
 Is an Access Token for HIRO Graph, and the mechanics to retrieve/update itself.
 I.e. it knows how to get a token and what to do when the token is considered invalidated.
 
-The API is simple, you create your token with a function `getToken` that returns a promise for an access token. Additionally you can pass an `onInvalidate` callback that, as the name suggests, is called when the token has been deemed invalidated.
+The API is simple, you create a token with a function `getToken` that returns a promise for an access token. Additionally you can pass an `onInvalidate` callback that, as the name suggests, is called when the token has been deemed invalidated.
 
 ```
 import { Token } from "hiro-graph-client";
@@ -21,38 +47,16 @@ const asyncTok = new Token({ getToken: () => {
 }});
 ```
 
-## Connection
-
-This is a persistent connection to the HIRO Graph server. With the HIRO Graph APIs exposed. It will work with WebSockets if possible, but fall's back to HTTP if not. It requires a `Token` which will then be used for all requests. All Exposed API methods return `Promise`s.
-
-```
-import { Connection } from "hiro-graph-client";
-
-const conn = new Connection({ endpoint: "http://localhost:8888", token: someTokenInstance });
-```
-
-The second argument to Connection can be a `Transport` if you have a custom one, or a set of options for the connection. If websockets are available, i.e. most modern browsers and when in node.js, then the default transport is a pool of websockets. The pool only has one socket by default, as in the browser this is most likely what you want, however on the backend you may wish to up this to more than s single connection.
-
-```
-import { Connection } from "hiro-graph-client";
-
-const conn = new Connection({
-        endpoint: "http://localhost:8888",
-        token: someTokenInstance
-    }, { 
-        poolSize: 10
-    });
-```
-
+More information on authenticating against the HIRO IAM can be found in the [HIRO Docs](https://docs.hiro.arago.co/hiro/current/developer/hiro-graph-api/index.html#how-to-get-a-token)
 
 ## Servlets
 
 HIRO Graph exposes many plugins via `/_*` endpoints (as HTTP) and only the most common APIs are exposed here. See the [servlets](/src/servlets/) directory for more info.
 
-In order to make arbitrary HTTP requests (with a valid Token) against HIRO Graph you can use `Connection.http.fetch` (and `Connection.http.defaultOptions()`) which acts just like the regular `fetch` API, but automatically adds the Access Token.
+In order to make arbitrary HTTP requests (with a valid Token) against HIRO Graph you can use `Client.http.fetch` (and `Client.http.defaultOptions()`) which acts just like the regular `fetch` API, but automatically adds the Access Token.
 
 ```
-const options = conn.http.defaultOptions();
+const options = client.http.defaultOptions();
 options.method = "POST";
 options.body = '{ "some": "data" }';
 const url = "/_some/uri";
@@ -60,3 +64,7 @@ conn.http.fetch(url, options).then(res => {
     //...
 });
 ```
+
+## EventStream (missing feature)
+
+The code exists for EventStream processing is only alpha at the moment. Recommended not to use as yet, and as such it is not exported directly.

--- a/packages/hiro-graph-client/src/client.js
+++ b/packages/hiro-graph-client/src/client.js
@@ -1,5 +1,5 @@
 /**
- *  A GraphIT connection
+ *  A GraphIT Client
  *
  *  It will use Websockets where possible and fall back to HTTP where WebSockets not supported.
  *  Event streams require WebSockets so those will not work witout websocket support.
@@ -38,7 +38,7 @@ const dereference = obj => {
     return Object.assign({}, obj);
 };
 
-export default class Connection {
+export default class Client {
     constructor({ endpoint, token }, transportOptions = {}) {
         this.endpoint = endpoint;
 
@@ -68,6 +68,7 @@ export default class Connection {
         }
 
         // This is where we keep our event streams.
+        // NB EventStream is not implemented yet
         this.events = [];
 
         // Bind our fetch for extension servlets.
@@ -87,11 +88,13 @@ export default class Connection {
      *  Make a clone of this connection, but with new
      */
     cloneWithNewToken(newToken) {
-        const cloned = new Connection({
-            endpoint: this.endpoint,
-            token: newToken,
-            transport: this.transport
-        });
+        const cloned = new Client(
+            {
+                endpoint: this.endpoint,
+                token: newToken
+            },
+            this.transport
+        );
         this._servlets.forEach(([name, methods]) =>
             cloned.addServlet(name, methods)
         );

--- a/packages/hiro-graph-client/src/index.js
+++ b/packages/hiro-graph-client/src/index.js
@@ -1,5 +1,6 @@
 import Token from "./token";
-import Connection from "./connection";
+import Client from "./client";
 import * as Errors from "./errors";
 
-export { Token, Connection, Errors };
+export default Client;
+export { Token, Errors };

--- a/packages/hiro-graph-client/src/token.js
+++ b/packages/hiro-graph-client/src/token.js
@@ -17,15 +17,15 @@ export default class Token {
         if (!this._tokenPromise) {
             this._tokenPromise = Promise.resolve(this._getToken())
                 .catch(err => {
-                    //flatten this, so another attempt can be made
+                    // flatten this, so another attempt can be made
                     this._tokenPromise = null;
-                    //returning a bogus token (null), should hopefully trigger this again,
-                    //waiting subscribers will receive it, fail, and try again.
+                    // returning a bogus token (null), should hopefully trigger this again,
+                    // waiting subscribers will receive it, fail, and try again.
                     console.error("ERROR GETTING TOKEN!", err);
                     return null;
                 })
                 .then(token => {
-                    this._invalidated = false; //this resolved one way or another...
+                    this._invalidated = false; // this resolved one way or another...
                     return token;
                 });
         }

--- a/packages/hiro-graph-client/src/transport-websocket.js
+++ b/packages/hiro-graph-client/src/transport-websocket.js
@@ -22,6 +22,7 @@ if (webSocketsAvailable) {
         ["CONNECTING", "OPEN", "CLOSING", "CLOSED"].forEach((prop, i) =>
             Object.defineProperty(WS, prop, { get: () => i })
         );
+        console.warn("patching node-websocket with readyState constants...");
     } else {
         // when this is called, we can relax
         console.warn(

--- a/packages/hiro-graph-orm-mappings/README.md
+++ b/packages/hiro-graph-orm-mappings/README.md
@@ -36,4 +36,3 @@ import Org from "hiro-graph-orm-mappings/lib/org";
 const schema = new Schema([Person, Org]);
 
 ```
-

--- a/packages/hiro-graph-orm/README.md
+++ b/packages/hiro-graph-orm/README.md
@@ -14,16 +14,18 @@ import Vertex from "hiro-graph-orm/lib/vertex";
 
 `npm install hiro-graph-orm hiro-graph-orm-mappings hiro-graph-client`
 
-### use
+### usage
+
+
 
 ```javascript
-import { Context } from "hiro-graph-orm";
+import HiroGraphOrm from "hiro-graph-orm";
 import { Token } from "hiro-graph-client";
 import mappings from "hiro-graph-orm-mappings";
 
 const token = new Token({ getToken: () => "some access token" });
 
-const ctx = new Context({ endpoint: "https://graphit/", token }, mappings);
+const ctx = new HiroGraphOrm({ endpoint: "https://graphit/", token }, mappings);
 
 //fetch the user of this access token.
 ctx.me().then(me => {
@@ -61,10 +63,33 @@ ctx.Person.find({
 ctx.Org.findById("arago.co"); //-> promise resolves with the arago.co vertex
 ctx.Person.findById("arago.co"); //-> promise rejects with a 404 error
 
-//do a gremlin query (get all memebers of all my orgs)
+//do a gremlin query (get all members of all my orgs)
 ctx.gremlin()
     .relation("Person", ["org"])
     .relation("Org", ["members"])
     .dedup()
     .execute(rootVertexId) //-> promise resolves to the returned vertices.
 ```
+
+## Validation
+
+This package contains a library to verify an your local schema mappings match up against a given OGIT schema. OGIT defines an ontology that restricts what attributes and connections a vertex can have, you may create a schema mapping that conflicts with this and this tool helps to identify any problems.
+
+@TODO: The tool only works with YAML ontologies, not the current TTL/RDF format. Also providing a binary would be nice ;).
+
+```javascript
+// NODE JS ONLY
+const { default: validate } = require("hiro-graph-orm/lib/schema/validate");
+
+const schema = require("/path/to/your/schema/mappings/array/module");
+
+const ontologyPath = "/path/to/your/OGIT/yaml/directory/or/file";
+
+const result = validate(schema, ontologyPath);
+
+console.log(result); // hopefully { errors: 0, detail: {} }
+```
+
+If there are errors, the `detail` object will contain much more information keyed by `ogit/_type`, to help you make the required changes to either the schema or the ontology.
+
+

--- a/packages/hiro-graph-orm/src/context/graph.js
+++ b/packages/hiro-graph-orm/src/context/graph.js
@@ -43,7 +43,8 @@ const returnOneOrThrow = result => {
 export function find(ctx, entity, query, options = {}) {
     const { querystring, placeholders } = parseLucene(query, entity);
     const luceneOptions = Object.assign({}, options, placeholders);
-    return ctx._connection
+    return ctx
+        .getClient()
         .lucene(querystring, luceneOptions)
         .then(vertexize(ctx, entity));
 }
@@ -65,7 +66,8 @@ export function findCount(ctx, entity, query, options = {}) {
     const luceneOptions = Object.assign({ limit: -1 }, options, placeholders, {
         count: true
     });
-    return ctx._connection
+    return ctx
+        .getClient()
         .lucene(querystring, luceneOptions)
         .then(([count]) => count);
 }
@@ -96,7 +98,8 @@ const cacheCheck = (
  */
 export function fetchMe(ctx) {
     const entity = ctx.getEntity("ogit/Person");
-    return ctx._connection
+    return ctx
+        .getClient()
         .me()
         .then(vertexize(ctx, entity))
         .then(returnOneOrThrow);
@@ -130,7 +133,8 @@ export function findById(ctx, entity, query, options = {}) {
         }
         const fetched = toFetch.length === 0
             ? Promise.resolve([])
-            : ctx._connection
+            : ctx
+                  .getClient()
                   .ids(toFetch, options)
                   .then(vertexize(ctx, entity));
 
@@ -170,7 +174,8 @@ export function create(ctx, entity, data, options = {}) {
         data.created_on = Date.now();
     }
     const dbData = entity.encode(data);
-    return ctx._connection
+    return ctx
+        .getClient()
         .create(entity.ogit, dbData, options)
         .then(vertexize(ctx, entity));
 }
@@ -180,7 +185,8 @@ export function create(ctx, entity, data, options = {}) {
  */
 export function update(ctx, entity, vertexId, data, options = {}) {
     const dbData = entity.encode(data);
-    return ctx._connection
+    return ctx
+        .getClient()
         .update(vertexId, dbData, options)
         .then(vertexize(ctx, entity));
 }
@@ -190,7 +196,8 @@ export function update(ctx, entity, vertexId, data, options = {}) {
  */
 export function replace(ctx, entity, vertexId, data, options = {}) {
     const dbData = entity.encode(data);
-    return ctx._connection
+    return ctx
+        .getClient()
         .replace(vertexId, dbData, options)
         .then(vertexize(ctx, entity));
 }
@@ -199,7 +206,7 @@ export function replace(ctx, entity, vertexId, data, options = {}) {
  * @ignore
  */
 export function deleteVertex(ctx, vertexId, options = {}) {
-    return ctx._connection.delete(vertexId, options);
+    return ctx.getClient().delete(vertexId, options);
 }
 
 /**
@@ -224,7 +231,7 @@ export function connect(
     const [inId, outId] = direction === "in"
         ? [source, target]
         : [target, source];
-    return ctx._connection.connect(verb, inId, outId, options);
+    return ctx.getClient().connect(verb, inId, outId, options);
 }
 
 /**
@@ -249,18 +256,16 @@ export function disconnect(
     const [inId, outId] = direction === "in"
         ? [source, target]
         : [target, source];
-    return ctx._connection.disconnect(verb, inId, outId, options);
+    return ctx.getClient().disconnect(verb, inId, outId, options);
 }
 
 /**
  * @ignore
  */
 export function gremlin(ctx, rootVertexId, query, options = {}) {
-    const queryResults = ctx._connection.gremlin(
-        rootVertexId,
-        query.toString(),
-        options
-    );
+    const queryResults = ctx
+        .getClient()
+        .gremlin(rootVertexId, query.toString(), options);
     if (options.raw) {
         return queryResults;
     }

--- a/packages/hiro-graph-orm/src/context/index.js
+++ b/packages/hiro-graph-orm/src/context/index.js
@@ -1,8 +1,5 @@
 /**
- *  Defines a Schema aware GraphIT connection library
- *
- *
- *
+ *  Defines a Schema aware GraphIT client library
  */
 import { queryBuilder } from "../gremlin";
 import {
@@ -20,7 +17,7 @@ import {
     fetchMe
 } from "./graph";
 import { createVertex } from "../vertex/graph";
-import { mapPromiseIfArray } from "../utils";
+import { mapPromiseIfArray, deprecationWarning } from "../utils";
 import {
     getRelationQuery,
     fetchVertices,
@@ -29,7 +26,7 @@ import {
 } from "./relations";
 import isPlainObject from "lodash.isplainobject";
 import Schema from "../schema";
-import { Connection } from "hiro-graph-client";
+import Client from "hiro-graph-client";
 
 //shorthand for creating the getCount/Ids/Vertices fetching functions
 const relationFetch = (method, relations, options = {}) =>
@@ -38,7 +35,7 @@ const relationFetch = (method, relations, options = {}) =>
 const noEntity = "_no_entity";
 
 /**
- *  The context is a wrapper for the schema and connection.
+ *  The context is a wrapper for the schema and client.
  *
  *  The major expost of the entire module.
  *
@@ -47,15 +44,15 @@ const noEntity = "_no_entity";
  */
 export default class Context {
     /**
-     *  @param {Connection|object} connectionSpec - This should be an `hiro-graph-client` `Connection` object,
+     *  @param {Client|object} clientSpec - This should be an `hiro-graph-client` `Client` object,
      *                                              or the constructor args to create one.
      *  @param {Schema|Array} schemaSpec - This should be a {@link Schema} or the constructor args to create one.
      *  @param {?Map} [cache=new&nbsp;Map()] - The vertex cache. Any object satisfying the `Map` interface should be OK.
      */
     constructor(connectionSpec, schemaSpec, cache = new Map()) {
-        let connection = connectionSpec;
+        let client = connectionSpec;
         if (isPlainObject(connectionSpec)) {
-            connection = new Connection(connectionSpec);
+            client = new Client(connectionSpec);
         }
 
         let schema = schemaSpec;
@@ -63,7 +60,7 @@ export default class Context {
             schema = new Schema(schemaSpec);
         }
 
-        this._connection = connection;
+        this._client = client;
         this._schema = schema;
         this._cache = cache;
         this._log = [];
@@ -83,12 +80,23 @@ export default class Context {
     }
 
     /**
-     * Get's the underlying GraphIT connection.
+     * Get's the underlying GraphIT Client.
      *
-     * @return {Connection}
+     * @return {Client}
+     */
+    getClient() {
+        return this._client;
+    }
+
+    /**
+     *  The old method for getting a connection, deprecated
+     *  @deprecated
      */
     getConnection() {
-        return this._connection;
+        return deprecationWarning(
+            () => this.getClient(),
+            "`getConnection` is deprecated, please use `getClient` instead. This method will be removed in a future version"
+        );
     }
 
     /**

--- a/packages/hiro-graph-orm/src/index.js
+++ b/packages/hiro-graph-orm/src/index.js
@@ -1,4 +1,5 @@
 import Schema from "./schema";
 import Context from "./context";
 
-export { Schema, Context };
+export default Context;
+export { Schema };

--- a/packages/hiro-graph-orm/src/schema/validate.js
+++ b/packages/hiro-graph-orm/src/schema/validate.js
@@ -16,6 +16,8 @@ import { $dangerouslyGetProps, $dangerouslyGetRelations } from "./entity";
  *  This is a `node` only piece of functionality and is intended to run as part of a linting
  *  or testing phase.
  *
+ *  NB this will not validate (yet) against a directory of `.ttl` files (like the current OGIT repo)
+ *
  *  @param {Schema} schema - the schema to check
  *  @param {string} ontologyLocation - a path to an ontology file or repo.
  *  @return {object} result

--- a/packages/hiro-graph-orm/src/types/externals.js
+++ b/packages/hiro-graph-orm/src/types/externals.js
@@ -1,3 +1,3 @@
 /**
- * @external {Connection} https://github.com/arago/js-graphit-client/blob/master/src/connection.js
+ * @external {Client} https://github.com/arago/hiro-graph-js/blob/master/packages/hiro-graph-client/src/connection.js
  */

--- a/packages/hiro-graph-orm/src/utils/index.js
+++ b/packages/hiro-graph-orm/src/utils/index.js
@@ -88,3 +88,18 @@ export const mapPromiseIfArray = fn => input =>
     Array.isArray(input)
         ? Promise.all(input.map(fn))
         : Promise.resolve(fn(input));
+
+/**
+ *  Warn on calling a deprecated function
+ *  By pass through args to a new function for now.
+ */
+export const deprecationWarning = (fn, warning) => {
+    let warned = false;
+    return (...args) => {
+        if (!warned) {
+            console.warn(warning);
+            warned = true;
+        }
+        return fn(...args);
+    };
+};

--- a/packages/hiro-graph-redux/src/index.js
+++ b/packages/hiro-graph-redux/src/index.js
@@ -4,7 +4,7 @@ import {
     createTaskFactory,
     createTaskAction
 } from "./create-action";
-import storeEnhancer from "./middleware";
+import createStoreEnhancer from "./middleware";
 import { setToken, cancelTask, resetTask, doLogin, doLogout } from "./actions";
 import graphReducer, {
     createTaskSelector,
@@ -31,7 +31,7 @@ export {
     createTaskAction,
     cancelTask,
     resetTask,
-    storeEnhancer,
+    createStoreEnhancer,
     setToken,
     getTaskState,
     getMyId,

--- a/packages/hiro-graph-redux/src/middleware.js
+++ b/packages/hiro-graph-redux/src/middleware.js
@@ -17,7 +17,7 @@ import { getMyId, $inflateVertex } from "./reducer";
 import ReduxToken from "./token";
 import { cancelablePromise } from "./utils";
 import { isUnknown } from "hiro-graph-client/lib/errors";
-import { Context } from "hiro-graph-orm";
+import Context from "hiro-graph-orm";
 import GraphVertex, { mergeRelations } from "hiro-graph-orm/lib/vertex/graph";
 import isPlainObject from "lodash.isplainobject";
 
@@ -28,9 +28,9 @@ const removeFromArray = (item, array) => {
     }
 };
 
-//this looks massively complex, but our middleware function
-//creates a redux middleware that is aware of our orm and provide helpers
-//to the action handlers inside.
+// this looks massively complex, but our middleware function
+// creates a redux middleware that is aware of our orm and provide helpers
+// to the action handlers inside.
 //
 //  This is the magic behind this module.
 //
@@ -40,7 +40,7 @@ const removeFromArray = (item, array) => {
 //
 // but we need access to subscribe.
 // So this needs to be a store enhancer...
-const storeEnhancer = (...ctxArgs) => createStore => (
+const createStoreEnhancer = (...ctxArgs) => createStore => (
     reducer,
     initialState,
     enhancer
@@ -63,7 +63,7 @@ function middleware(ctxArgs, { dispatch: next, getState, subscribe }) {
         )
     ) {
         throw new Error(
-            "could not create middleware, arguments not valid Context or Context constructor arguments"
+            "could not create middleware, arguments not valid HiroGraphOrm or HiroGraphOrm constructor arguments"
         );
     }
 
@@ -131,7 +131,7 @@ function middleware(ctxArgs, { dispatch: next, getState, subscribe }) {
                 }
                 return next(action);
             case GRAPH_LOGIN:
-                orm.getConnection().getToken().invalidate();
+                orm.getClient().getToken().invalidate();
                 return next(action);
             case GRAPH_LOGOUT:
                 //don't invalidate the token, but call the logout handler setup
@@ -188,9 +188,7 @@ function middleware(ctxArgs, { dispatch: next, getState, subscribe }) {
     orm._notifyCacheFlush = fn => notifyFlush.push(fn);
 
     //now grab the token to wire it in.
-    //I'd rather have a getter here than relying on the tight coupling, but hey, that
-    //would mean altering both js-graph-orm AND js-graphit-client
-    const token = orm.getConnection().getToken();
+    const token = orm.getClient().getToken();
     if (!(token instanceof ReduxToken)) {
         throw new Error(
             "could not create middleware, Graph Token not a `ReduxToken`"
@@ -226,7 +224,7 @@ function middleware(ctxArgs, { dispatch: next, getState, subscribe }) {
     return dispatch;
 }
 
-export default storeEnhancer;
+export default createStoreEnhancer;
 
 //this function tries to guard against storing vertices directly in state.
 const checkResultsForVertices = key => results => {


### PR DESCRIPTION
moving `hiro-graph-client`.Connection to default export
moving `hiro-graph-orm`.Context to default export
remaning `hiro-graph-redux`.storeEnhancer to `createStoreEnhancer`

update documentation to reflect, and updating internal references

fix: hiro-graph-redux bug where bad token in localstorage would prevent
login.