### PR TITLE
Allow mutable Schema

### DIFF
--- a/packages/hiro-graph-client/src/client.js
+++ b/packages/hiro-graph-client/src/client.js
@@ -332,7 +332,7 @@ export default class Client {
             query,
             limit,
             offset,
-            count,
+            count: String(count),
             ...placeholders
         };
         if (order) {


### PR DESCRIPTION
- 🎉 ORM Schema can now be changed at runtime using `{immutable: false}` option with`Schema.setSchema` & `Schema.updateSchema` the HiroGraphORM with listen to changes and update itself accordingly
- 🎉 Allow `{raw: true}` as a `find/findOne/search/findById` option
- 🐛 Bugfix `orm.findCount` not returning count correctly