### PR TITLE
Bugfixes, tag handling, and findOne limit

### DIFF
--- a/packages/hiro-graph-orm/__tests__/context.spec.js
+++ b/packages/hiro-graph-orm/__tests__/context.spec.js
@@ -105,4 +105,13 @@ describe("mock transport test", () => {
             "notARealProp asc"
         );
     });
+
+    it("should force limit to 1 when performing a `findOne`", async () => {
+        const node1 = simpleTestNodeGenerator("node-1");
+        client.enqueueMockResponse([node1]);
+        await ctx.Simple.findOne({});
+        expect(client.retrieveLastRequest()).toMatchObject({
+            body: { limit: 1 }
+        });
+    });
 });

--- a/packages/hiro-graph-orm/__tests__/schema.spec.js
+++ b/packages/hiro-graph-orm/__tests__/schema.spec.js
@@ -134,6 +134,31 @@ describe("Entities", function() {
         });
     });
 
+    it("should handle all internal properties correctly", () => {
+        const knownDate = new Date(Date.parse("2016-05-26T12:50:37.577Z"));
+        const input = {
+            "ogit/_id": "some-id",
+            "ogit/_type": "ogit/Simple",
+            "ogit/_created-on": knownDate.getTime(),
+            "ogit/_modified-on": knownDate.getTime() + 1,
+            "ogit/_created-by": "some-creator",
+            "ogit/_modified-by": "some-modifier",
+            "ogit/_content": "some-content",
+            "ogit/_tags": "a,  comma-seperated, list,of tags "
+        };
+        const output = {
+            _id: "some-id",
+            _type: "Simple",
+            "_created-on": knownDate.getTime(),
+            "_modified-on": knownDate.getTime() + 1,
+            "_created-by": "some-creator",
+            "_modified-by": "some-modifier",
+            _content: "some-content",
+            _tags: ["a", "comma-seperated", "list", "of tags"]
+        };
+        expect(entity.decode(input)).toEqual(output);
+    });
+
     const relationParsingTests = [
         {
             name: "simple",

--- a/packages/hiro-graph-orm/src/context/graph.js
+++ b/packages/hiro-graph-orm/src/context/graph.js
@@ -90,7 +90,9 @@ export function find(ctx, entity, query, options = {}) {
  * @ignore
  */
 export function findOne(ctx, entity, query, options = {}) {
-    return find(ctx, entity, query, options).then(returnOneOrThrow);
+    // force the limit to be 1
+    const limitOneOptions = Object.assign({}, options, { limit: 1 });
+    return find(ctx, entity, query, limitOneOptions).then(returnOneOrThrow);
 }
 
 /**

--- a/packages/hiro-graph-orm/src/schema/entity.js
+++ b/packages/hiro-graph-orm/src/schema/entity.js
@@ -148,23 +148,23 @@ const internalProps = [
     {
         src: "ogit/_id",
         dst: "_id",
-        encode: stringCodec.decode,
-        decode: stringCodec.encode,
+        encode: stringCodec.encode,
+        decode: stringCodec.decode,
         required: false
     },
     {
         //_content and fields will be moved to ontology definition, e.g. github.com/arago/OGIT
         src: "ogit/_content",
         dst: "_content",
-        encode: stringCodec.decode,
-        decode: stringCodec.encode,
+        encode: stringCodec.encode,
+        decode: stringCodec.decode,
         required: false
     },
     {
         src: "ogit/_tags",
         dst: "_tags",
-        encode: listCodec.decode,
-        decode: listCodec.encode,
+        encode: listCodec.encode,
+        decode: listCodec.decode,
         required: false
     }
 ];


### PR DESCRIPTION
- Fixes handling of `ogit/_tags` field.
- Forces options to `limit = 1` on a `ctx.findOne` call