### PR TITLE
Expose `setOnLogoutHook`

### DIFF
--- a/packages/hiro-graph-redux/src/index.js
+++ b/packages/hiro-graph-redux/src/index.js
@@ -5,7 +5,14 @@ import {
     createTaskAction
 } from "./create-action";
 import createStoreEnhancer from "./middleware";
-import { setToken, cancelTask, resetTask, doLogin, doLogout } from "./actions";
+import { 
+    setToken,
+    cancelTask,
+    resetTask,
+    doLogin,
+    doLogout,
+    setOnLogoutHook
+} from "./actions";
 import graphReducer, {
     createTaskSelector,
     createVertexSelector,
@@ -41,5 +48,6 @@ export {
     implicitOauth,
     loginTaskSelector,
     doLogin,
-    doLogout
+    doLogout,
+    setOnLogoutHook
 };

--- a/packages/hiro-graph-redux/src/index.js
+++ b/packages/hiro-graph-redux/src/index.js
@@ -5,7 +5,7 @@ import {
     createTaskAction
 } from "./create-action";
 import createStoreEnhancer from "./middleware";
-import { 
+import {
     setToken,
     cancelTask,
     resetTask,


### PR DESCRIPTION
Sometimes it's necessary to do some work upon logout. 
Currently it's only possible if we write 
`import { setOnLogoutHook } from 'hiro-graph-redux/lib/actions;` 
Which looks kinda hacky.