### PR TITLE
#164924956: remove quotes for terms in placeholders

### DIFF
--- a/packages/hiro-graph-lucene/src/index.js
+++ b/packages/hiro-graph-lucene/src/index.js
@@ -335,7 +335,6 @@ function luceneTerm(context, field, values) {
     }
     return values
         .map(prop.encode) // encode for graphit with our mapping
-        .map(checkTermForQuoting) //quote if needed
         .map(term => createPlaceholder(context.placeholders, term))
         .map(
             term =>

--- a/packages/hiro-graph-orm/__tests__/lucene.spec.js
+++ b/packages/hiro-graph-orm/__tests__/lucene.spec.js
@@ -125,7 +125,7 @@ describe("Lucene Query Generator:", function() {
                 `ogit\\/_content.ngram:$ph_13) +_missing_:"/key13" +_missing_:"/key14"`,
                 `+ogit\\/_content.ngram:$ph_14`
             ].join(" "),
-            placeholders: ['"value"', '"multi"']
+            placeholders: ["value", "multi"]
         },
         {
             name: "strings with quotes",


### PR DESCRIPTION
Remove quoting step for methods $or, $and, $not and $must because we do not need quotes with placeholder replacement.
