### PR TITLE
#170148513: Fix deps

### DIFF
--- a/packages/hiro-graph-orm-mappings/src/helper.ts
+++ b/packages/hiro-graph-orm-mappings/src/helper.ts
@@ -1,4 +1,10 @@
-export const cleanName = (originalNs: string, safeNs: string, name: string) => {
+import { IDefinitionData, IOutput } from "./types";
+
+export const cleanName = (
+  originalNs: string,
+  safeNs: string,
+  name: string,
+): string => {
     let output = name;
 
     if (safeNs.startsWith("oslc")) {

--- a/packages/hiro-graph-orm-mappings/src/index.ts
+++ b/packages/hiro-graph-orm-mappings/src/index.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import { join } from "path";
 import shell from "shelljs";
 import Mustache from "mustache";
+import { IDefinition } from "@hiro-graph/orm";
 
 import {
     getRequiredAttributes,
@@ -18,6 +19,7 @@ import {
 import { mapRelationship } from "./relations";
 
 import config from "../config.json";
+import { IOutput, IToBeDone } from "./types";
 
 const tbd: IToBeDone = {};
 

--- a/packages/hiro-graph-orm-mappings/src/regex.ts
+++ b/packages/hiro-graph-orm-mappings/src/regex.ts
@@ -1,4 +1,5 @@
 import { mapRelationship } from "./relations";
+import { IDefinitionData } from "./types";
 
 const mandatoryAttributesRegex = /ogit:mandatory-attributes \(([^);]+)/;
 const optionalAttributesRegex = /ogit:optional-attributes \(([^);]+)/;

--- a/packages/hiro-graph-orm-mappings/src/relations.ts
+++ b/packages/hiro-graph-orm-mappings/src/relations.ts
@@ -1,4 +1,5 @@
 import { mapping } from "../config.json";
+import { IMapping } from "./types";
 
 export const mapRelationship = (value: string, fallback: string | number) => {
     const mapped = (mapping as IMapping)[value];

--- a/packages/hiro-graph-orm-mappings/src/templates/typings.mustache
+++ b/packages/hiro-graph-orm-mappings/src/templates/typings.mustache
@@ -11,14 +11,6 @@ export interface IDefinitionData {
     [index: string]: string;
 }
 
-export interface IDefinition {
-    name: string;
-    ogit: string;
-    required?: IDefinitionData;
-    optional?: IDefinitionData;
-    relations?: IDefinitionData;
-}
-
 export type MappedTypes = keyof typeof VertexLookup;
 
 {{#exports}}
@@ -30,4 +22,3 @@ export namespace VertexLookup {
     export const {{name}}: {{name}}Vertex;
 {{/exports}}
 }
-

--- a/packages/hiro-graph-orm-mappings/src/types.d.ts
+++ b/packages/hiro-graph-orm-mappings/src/types.d.ts
@@ -1,18 +1,11 @@
+import { IDefinition } from "@hiro-graph/orm";
+
 interface IDefinitionData {
     [index: string]: string;
 }
 
 interface IMapping {
     [index: string]: string;
-}
-
-interface IDefinition {
-    name: string;
-    ogit: string;
-    required?: IDefinitionData;
-    optional?: IDefinitionData;
-    relations?: IDefinitionData;
-    [name: string]: string | IDefinitionData | undefined;
 }
 
 interface IOutput {

--- a/packages/hiro-graph-orm/index.d.ts
+++ b/packages/hiro-graph-orm/index.d.ts
@@ -17,6 +17,7 @@ export interface IDefinition {
   required?: IDefinitionData;
   optional?: IDefinitionData;
   relations?: IDefinitionData;
+  [name: string]: string | IDefinitionData | undefined;
 }
 
 interface IQueryOptions {


### PR DESCRIPTION
 * Move interface IDefinition to orm
 * Remove redundant interface in typings.mustache
 * Add import/export types

# Conflicts:
#	packages/hiro-graph-orm-mappings/src/helper.ts
#	packages/hiro-graph-orm-mappings/src/index.ts
#	packages/hiro-graph-orm-mappings/src/regex.ts
#	packages/hiro-graph-orm-mappings/src/relations.ts
#	packages/hiro-graph-orm-mappings/src/types.d.ts