### PR TITLE
174929122: Fix typo in variable servlet Factory declaration

### DIFF
--- a/packages/hiro-graph-client/index.d.ts
+++ b/packages/hiro-graph-client/index.d.ts
@@ -504,7 +504,7 @@ export interface AuthServlet {
 
 export declare const appsServletFactory: () => AppsServlet;
 export declare const kiServletFactory: () => KiServlet;
-export declare const variablesSerlvetFactory: () => VariablesServlet;
+export declare const variablesServletFactory: () => VariablesServlet;
 
 // Client
 


### PR DESCRIPTION
It was necessary to add variables servlet to KIM and IDE was swearing on undefined constant. The cause is that the declaration was written with a typo.
https://www.pivotaltracker.com/story/show/174929122 