### PR TITLE
Update DataScope type and fix client 'writets' type

### DIFF
--- a/packages/hiro-graph-client/index.d.ts
+++ b/packages/hiro-graph-client/index.d.ts
@@ -373,6 +373,11 @@ export interface TimeseriesResponse {
   value: string;
 }
 
+export interface TimeseriesValue {
+  timestamp: number;
+  value: PlainObject | number | string | Array<string | number | PlainObject[]>;
+}
+
 // Servlets
 
 interface PlainObject {
@@ -749,9 +754,7 @@ export default class Client {
   // timeseries value type is based on client.js implementation and usage in hiro-desktop-utils
   writets: (
     timeseriesId: string,
-    value:
-      | { timestamp: number; value: string }
-      | Array<{ timestamp: number; value: string }>,
+    value: TimeseriesValue,
   ) => Promise<TimeseriesResponse[]>;
 
   addServlet(

--- a/packages/hiro-graph-client/index.d.ts
+++ b/packages/hiro-graph-client/index.d.ts
@@ -745,11 +745,6 @@ export default class Client {
     },
   ) => Promise<T[]>;
 
-  writets: (
-    timeseriesId: string,
-    value: { timestamp: number; value: PlainObject | Array<PlainObject> },
-  ) => Promise<TimeseriesResponse[]>;
-
   addServlet(
     prefix: string,
     servletMethods: ServletMethods,

--- a/packages/hiro-graph-client/index.d.ts
+++ b/packages/hiro-graph-client/index.d.ts
@@ -147,6 +147,7 @@ export namespace OGIT {
   export interface DataScope extends SafeNode {
     'ogit/name': string;
     'ogit/description'?: string;
+    'ogit/licenseSubject'?: string;
   }
 }
 

--- a/packages/hiro-graph-client/index.d.ts
+++ b/packages/hiro-graph-client/index.d.ts
@@ -746,6 +746,7 @@ export default class Client {
     },
   ) => Promise<T[]>;
 
+  // timeseries value type is based on client.js implementation and usage in hiro-desktop-utils
   writets: (
     timeseriesId: string,
     value: { timestamp: number; value: string } | Array<{ timestamp: number; value: string }>,

--- a/packages/hiro-graph-client/index.d.ts
+++ b/packages/hiro-graph-client/index.d.ts
@@ -749,7 +749,9 @@ export default class Client {
   // timeseries value type is based on client.js implementation and usage in hiro-desktop-utils
   writets: (
     timeseriesId: string,
-    value: { timestamp: number; value: string } | Array<{ timestamp: number; value: string }>,
+    value:
+      | { timestamp: number; value: string }
+      | Array<{ timestamp: number; value: string }>,
   ) => Promise<TimeseriesResponse[]>;
 
   addServlet(

--- a/packages/hiro-graph-client/index.d.ts
+++ b/packages/hiro-graph-client/index.d.ts
@@ -745,6 +745,11 @@ export default class Client {
     },
   ) => Promise<T[]>;
 
+  writets: (
+    timeseriesId: string,
+    value: { timestamp: number; value: string } | Array<{ timestamp: number; value: string }>,
+  ) => Promise<TimeseriesResponse[]>;
+
   addServlet(
     prefix: string,
     servletMethods: ServletMethods,

--- a/packages/hiro-graph-client/index.d.ts
+++ b/packages/hiro-graph-client/index.d.ts
@@ -375,7 +375,7 @@ export interface TimeseriesResponse {
 
 export interface TimeseriesValue {
   timestamp: number;
-  value: PlainObject | number | string | Array<string | number | PlainObject[]>;
+  value: PlainObject | number | string | Array<string | number | PlainObject>;
 }
 
 // Servlets
@@ -754,7 +754,7 @@ export default class Client {
   // timeseries value type is based on client.js implementation and usage in hiro-desktop-utils
   writets: (
     timeseriesId: string,
-    value: TimeseriesValue,
+    value: TimeseriesValue | TimeseriesValue[],
   ) => Promise<TimeseriesResponse[]>;
 
   addServlet(

--- a/packages/hiro-graph-client/src/client.js
+++ b/packages/hiro-graph-client/src/client.js
@@ -566,7 +566,7 @@ export default class Client {
     /**
      *  Write timeseries values (only ogit/Timeseries vertices)
      *
-     *  values are { timestamp: millisecond unix, value: PlainObject | number | string | Array<string | number | PlainObject[]> }
+     *  values are { timestamp: millisecond unix, value: PlainObject | number | string | Array<string | number | PlainObject> }
      */
     writets(timeseriesId, values) {
         let items = values;

--- a/packages/hiro-graph-client/src/client.js
+++ b/packages/hiro-graph-client/src/client.js
@@ -566,7 +566,7 @@ export default class Client {
     /**
      *  Write timeseries values (only ogit/Timeseries vertices)
      *
-     *  values are { timeseriesId: string, value: {timestamp: number; value: PlainObject | Array<PlainObject>}}
+     *  values are { timestamp: millisecond unix, value: string value }
      */
     writets(timeseriesId, values) {
         let items = values;

--- a/packages/hiro-graph-client/src/client.js
+++ b/packages/hiro-graph-client/src/client.js
@@ -566,7 +566,7 @@ export default class Client {
     /**
      *  Write timeseries values (only ogit/Timeseries vertices)
      *
-     *  values are { timestamp: millisecond unix, value: string value }
+     *  values are { timestamp: millisecond unix, value: PlainObject | number | string | Array<string | number | PlainObject[]> }
      */
     writets(timeseriesId, values) {
         let items = values;


### PR DESCRIPTION
- fix `writets` client type (value inside value)
- update `licenseSubject` to DataScope type 

Usage with removing ts-ignore and kat-worker fix in hiro-desktop-utils https://github.com/arago/hiro-desktop-utils/pull/209